### PR TITLE
Reset imported src files on each call to flatten

### DIFF
--- a/helpers/find-file.js
+++ b/helpers/find-file.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const glob = require('glob-promise')
 const path = require('path')
-const { importedSrcFiles } = require('./variables')
+
+const { getImportedSrcFiles } = require('./variables')
 const constants = require('./constants')
 const changeRelativePathToAbsolute = require('./change-relative-path-to-absolute')
 
@@ -56,6 +57,9 @@ async function byNameAndReplaceInnerRecursively(importStatement, updatedFileCont
 }
 
 async function byNameAndReplaceInnerRecursivelyInner(importStatement, updatedFileContent, dir, dependencyPath, srcFiles, j, resolve, reject, importIsReplacedBefore) {
+	// Get the variable storing imported src files.
+	const importedSrcFiles = getImportedSrcFiles()
+
 	if (j >= srcFiles.length) return resolve({ flattenFileContent: updatedFileContent, importIsReplacedBefore })
 
 	let isAbsolutePath = !dependencyPath.startsWith(constants.DOT)

--- a/helpers/replace-all-imports-in-current-layer.js
+++ b/helpers/replace-all-imports-in-current-layer.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
-const { importedSrcFiles } = require('./variables')
+
+const { getImportedSrcFiles } = require('./variables')
 const constants = require('./constants')
 const findFile = require('./find-file')
 const updateImportObjectLocationInTarget = require('./update-import-object-location-in-target')
@@ -15,6 +16,9 @@ async function replaceAllImportsInCurrentLayer(i, importObjs, updatedFileContent
 }
 
 async function replaceAllImportsInCurrentLayerInner(i, importObjs, updatedFileContent, dir, resolve) {
+	// Get the variable storing imported src files.
+	const importedSrcFiles = getImportedSrcFiles()
+
 	if (i >= importObjs.length) {
 		return resolve(updatedFileContent)
 	}

--- a/helpers/variables.js
+++ b/helpers/variables.js
@@ -34,4 +34,12 @@ function processVariables(args) {
 	return variables
 }
 
-module.exports = { processVariables, importedSrcFiles }
+function resetImportedSrcFiles () {
+	importedSrcFiles = {}
+}
+
+function getImportedSrcFiles () {
+	return importedSrcFiles
+}
+
+module.exports = { processVariables, resetImportedSrcFiles, getImportedSrcFiles }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const fs = require('fs')
 
-const { processVariables } = require('./helpers/variables')
+const { processVariables, resetImportedSrcFiles } = require('./helpers/variables')
 const log = require('./helpers/logger')
 const constants = require('./helpers/constants')
 const replaceAllImportsRecursively = require('./helpers/replace-all-imports-recursively')
@@ -29,6 +29,9 @@ async function main(args) {
 }
 
 async function flatten(inputFilePath) {
+	// Reset the global variable to store imported source files.
+	resetImportedSrcFiles()
+
 	inputFilePath = path.resolve(inputFilePath)
 
 	const inputFileContent = fs.readFileSync(inputFilePath, 'utf8')


### PR DESCRIPTION
Part of https://github.com/vulcanize/watcher-ts/issues/23

- Reset imported src files on each call to flatten:
  - Earlier, on multiple calls to the exported function flatten, if the input contracts had common imports, they would be placed in the output of just a single contract and not all the contracts where they are used. The issue was caused due to usage of a global variable (importedSrcFiles) to store the imported files.
  - Now that the variable to store the imported source files is reset on each call to flatten a contract, the common imports are output for every contract that imports them.